### PR TITLE
Add a new copy of dockerfile for building duckpan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,63 @@
+FROM vvoronin/ubuntu-tools
+MAINTAINER Xinjiang Shao <shaoxinjiang@gmail.com>
+
+RUN /tools/apt build-essential wget git libssl-dev nodejs npm
+
+# Install Perl
+ENV TARGET_PERL_FULL 5.16.3
+ENV TARGET_PERL      5.16
+ENV TARGET_PERLBREW  0.76
+
+ENV PERLBREW_ROOT=/perl5
+
+RUN bash -c '\wget -O - http://install.perlbrew.pl | bash' &&\
+        /perl5/bin/perlbrew init &&\
+        /perl5/bin/perlbrew install -j 4 perl-$TARGET_PERL_FULL &&\
+        /perl5/bin/perlbrew install-cpanm &&\
+        /perl5/bin/perlbrew switch perl-$TARGET_PERL_FULL
+        
+ENV PERLBREW_ROOT=/perl5 \
+    PATH=/perl5/bin:/perl5/perls/perl-$TARGET_PERL_FULL/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    PERLBREW_PERL=perl-$TARGET_PERL_FULL \
+    PERLBREW_VERSION=$TARGET_PERLBREW \
+    PERLBREW_MANPATH=/perl5/perls/perl-$TARGET_PERL_FULL/man \
+    PERLBREW_PATH=/perl5/bin:/perl5/perls/perl-$TARGET_PERL_FULL/bin \
+    PERLBREW_SKIP_INIT=1
+
+RUN perlbrew info
+RUN perl -v
+RUN cpanm --version
+
+# Install DuckPAN
+
+RUN cpanm --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org Term::ReadKey@2.32
+
+# RUN useradd -ms /bin/bash ddg
+# USER ddg
+# WORKDIR /home/ddg
+# ENV USER ddg
+
+RUN cpanm --notest --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org App::DuckPAN 
+# Clone repositories and install their dependencies
+RUN git clone https://github.com/duckduckgo/zeroclickinfo-goodies.git
+RUN cd zeroclickinfo-goodies &&\
+    npm install -g uglify-js handlebars &&\
+    cpanm --notest Dist::Zilla &&\
+    dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org &&\
+    dzil listdeps | grep -ve '^\W' | cpanm --mirror http://www.cpan.org/ --mirror http://duckpan.org &&\
+    cd .. && rm -rf zeroclickinfo-goodies
+
+RUN git clone https://github.com/duckduckgo/zeroclickinfo-spice.git
+RUN cd zeroclickinfo-spice &&\
+    npm install -g uglify-js handlebars &&\
+    cpanm --notest Dist::Zilla &&\
+    dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org &&\
+    dzil listdeps | grep -ve '^\W' | cpanm --mirror http://www.cpan.org/ --mirror http://duckpan.org &&\
+    cd .. && rm -rf zeroclickinfo-spice
+RUN duckpan check
+
+WORKDIR /home/ddg
+VOLUME /home/ddg
+EXPOSE 5000
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,21 +2,32 @@ FROM rsrchboy/perl-v5.16
 MAINTAINER Xinjiang Shao <shaoxinjiang@gmail.com>
 
 RUN apt-get update \
-    && apt-get install -y git libssl-dev \
+    && apt-get install -y curl \
+    git \
+    libssl-dev \
+    libmpfr-dev \
+    nodejs \
+    npm \
+    nodejs-legacy \
     && rm -fr /var/lib/apt/lists/*
+RUN npm install -g handlebars@1.3.0 uglifyjs
+RUN cpanm --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org Dist::Zilla
 
-# Install cpanminus
-RUN perlbrew install-cpanm 
-
-RUN perl -v
-RUN cpanm --version
-
-# Install DuckPAN
-RUN cpanm --notest --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org Dist::Zilla
-
+# Install DuckPAN 
 RUN cpanm --notest --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org App::DuckPAN 
 
-RUN duckpan check
+# Install Dependencies for Spice and Goodies
+RUN git clone --depth=50 https://github.com/duckduckgo/zeroclickinfo-spice.git
+RUN cd zeroclickinfo-spice &&\
+    dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm --skip-installed --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org &&\        
+    dzil listdeps | grep -ve '^\W'| cpanm --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org &&\
+    cd .. && rm -rf zeroclickinfo-spice
+
+RUN git clone --depth=50 https://github.com/duckduckgo/zeroclickinfo-goodies.git
+RUN cd zeroclickinfo-goodies &&\
+    dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm --skip-installed --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org &&\        
+    dzil listdeps | grep -ve '^\W' | cpanm --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org &&\
+    cd .. && rm -rf zeroclickinfo-goodies
 
 # Clean out downloaded modules.
 RUN rm -r /root/.cpanm/latest-build/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,72 +1,26 @@
-FROM vvoronin/ubuntu-tools
+FROM rsrchboy/perl-v5.16
 MAINTAINER Xinjiang Shao <shaoxinjiang@gmail.com>
 
-RUN /tools/apt build-essential wget git libssl-dev nodejs npm
+RUN apt-get update \
+    && apt-get install -y git libssl-dev \
+    && rm -fr /var/lib/apt/lists/*
 
-# Install Perl
-ENV TARGET_PERL_FULL 5.16.3
-ENV TARGET_PERL      5.16
-ENV TARGET_PERLBREW  0.76
+# Install cpanminus
+RUN perlbrew install-cpanm 
 
-ENV PERLBREW_ROOT=/perl5
-
-RUN bash -c '\wget -O - http://install.perlbrew.pl | bash' &&\
-        /perl5/bin/perlbrew init &&\
-        /perl5/bin/perlbrew install -j 4 perl-$TARGET_PERL_FULL &&\
-        /perl5/bin/perlbrew install-cpanm &&\
-        /perl5/bin/perlbrew switch perl-$TARGET_PERL_FULL
-        
-ENV PERLBREW_ROOT=/perl5 \
-    PATH=/perl5/bin:/perl5/perls/perl-$TARGET_PERL_FULL/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
-    PERLBREW_PERL=perl-$TARGET_PERL_FULL \
-    PERLBREW_VERSION=$TARGET_PERLBREW \
-    PERLBREW_MANPATH=/perl5/perls/perl-$TARGET_PERL_FULL/man \
-    PERLBREW_PATH=/perl5/bin:/perl5/perls/perl-$TARGET_PERL_FULL/bin \
-    PERLBREW_SKIP_INIT=1
-
-RUN perlbrew info
 RUN perl -v
 RUN cpanm --version
 
 # Install DuckPAN
-RUN cpanm --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org Term::ReadKey@2.32
-
-# RUN useradd -ms /bin/bash ddg
-# USER ddg
-# WORKDIR /home/ddg
-# ENV USER ddg
+RUN cpanm --notest --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org Dist::Zilla
 
 RUN cpanm --notest --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org App::DuckPAN 
 
-# Clone repositories and install their dependencies
-RUN git clone https://github.com/duckduckgo/zeroclickinfo-goodies.git
-RUN cd zeroclickinfo-goodies &&\
-    npm install -g uglify-js handlebars &&\
-    cpanm --notest Dist::Zilla &&\
-    dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org &&\
-    dzil listdeps | grep -ve '^\W' | cpanm --mirror http://www.cpan.org/ --mirror http://duckpan.org &&\
-    cd .. && rm -rf zeroclickinfo-goodies
-
-RUN git clone https://github.com/duckduckgo/zeroclickinfo-spice.git
-RUN cd zeroclickinfo-spice &&\
-    npm install -g uglify-js handlebars &&\
-    cpanm --notest Dist::Zilla &&\
-    dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org &&\
-    dzil listdeps | grep -ve '^\W' | cpanm --mirror http://www.cpan.org/ --mirror http://duckpan.org &&\
-    cd .. && rm -rf zeroclickinfo-spice
-
-RUN git clone https://github.com/duckduckgo/zeroclickinfo-fathead.git
-RUN cd zeroclickinfo-fathead &&\
-    dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org &&\
-    dzil listdeps | grep -ve '^\W' | cpanm --mirror http://www.cpan.org/ --mirror http://duckpan.org &&\
-    cd .. && rm -rf zeroclickinfo-fathead
-
 RUN duckpan check
+
 # Clean out downloaded modules.
 RUN rm -r /root/.cpanm/latest-build/*
 
 WORKDIR /home/ddg
 VOLUME /home/ddg
 EXPOSE 5000
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ RUN perl -v
 RUN cpanm --version
 
 # Install DuckPAN
-
 RUN cpanm --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org Term::ReadKey@2.32
 
 # RUN useradd -ms /bin/bash ddg
@@ -38,6 +37,7 @@ RUN cpanm --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org Ter
 # ENV USER ddg
 
 RUN cpanm --notest --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org App::DuckPAN 
+
 # Clone repositories and install their dependencies
 RUN git clone https://github.com/duckduckgo/zeroclickinfo-goodies.git
 RUN cd zeroclickinfo-goodies &&\
@@ -54,7 +54,16 @@ RUN cd zeroclickinfo-spice &&\
     dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org &&\
     dzil listdeps | grep -ve '^\W' | cpanm --mirror http://www.cpan.org/ --mirror http://duckpan.org &&\
     cd .. && rm -rf zeroclickinfo-spice
+
+RUN git clone https://github.com/duckduckgo/zeroclickinfo-fathead.git
+RUN cd zeroclickinfo-fathead &&\
+    dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org &&\
+    dzil listdeps | grep -ve '^\W' | cpanm --mirror http://www.cpan.org/ --mirror http://duckpan.org &&\
+    cd .. && rm -rf zeroclickinfo-fathead
+
 RUN duckpan check
+# Clean out downloaded modules.
+RUN rm -r /root/.cpanm/latest-build/*
 
 WORKDIR /home/ddg
 VOLUME /home/ddg

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+IMAGE = soleo/duckpan:latest
+
+default:
+	docker build -t $(IMAGE) .
+hack:
+	docker run -ti --rm -v `pwd`:/home/ddg -p 5000:5000 $(IMAGE)
+push:
+	docker push $(IMAGE)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ # Checkout your own fork. e.g.
 $ cd ~/projects && git clone https://github.com/soleo/zeroclickinfo-spice.git
 $ # Bash from container
 $ docker run -ti -p 5000:5000 -v ~/projects/zeroclickinfo-spice:/home/ddg/zeroclickinfo-spice --rm soleo/duckpan bash
-# duckpan server
+# cd /home/ddg/zeroclickinfo-spice && duckpan server
 ```
 
 Start hacking and building new feature from there! You can visit ``localhost:5000`` to test your stuff now.

--- a/README.md
+++ b/README.md
@@ -2,3 +2,37 @@ duckpan-docker
 ==============
 
 A Dockerfile for installing DuckPAN.
+
+
+### Requirements
+
+* docker >= 1.12
+
+
+### Build/Pull Image
+
+Pull from docker.io Hub, or build locally
+
+```console
+$ docker pull soleo/duckpan
+```
+
+```console
+$ docker build -t soleo/duckpan .
+```
+
+### Run
+
+```console
+$ # Checkout your own fork. e.g.
+$ cd ~/projects && git clone https://github.com/soleo/zeroclickinfo-spice.git
+$ # Bash from container
+$ docker run -ti -p 5000:5000 -v ~/projects/zeroclickinfo-spice:/home/ddg/zeroclickinfo-spice --rm soleo/duckpan bash
+# duckpan server
+```
+
+Start hacking and building new feature from there! You can visit ``localhost:5000`` to test your stuff now.
+
+
+
+


### PR DESCRIPTION
@moollaza @jagtalon 

Looks like this repo has not been touched for a long time by anyone. When I was working on the issue related to swiftdocs, I started to PR to use docker to build duckpan so that I can work locally. If you're interested, you could check the images out from https://hub.docker.com/r/soleo/duckpan/ or build locally(It will take  a long time to build).  Let me know what you guys think. It would be cool if this can get merged. Cheers!