### PR TITLE
remove --mirror http://duckpan.org for Dist::Zilla, App::DuckPAN

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,10 @@ RUN apt-get update \
     nodejs-legacy \
     && rm -fr /var/lib/apt/lists/*
 RUN npm install -g handlebars@1.3.0 uglifyjs
-RUN cpanm --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org Dist::Zilla
+RUN cpanm --notest Dist::Zilla
 
 # Install DuckPAN 
-RUN cpanm --notest --skip-installed --mirror http://www.cpan.org/ --mirror http://duckpan.org App::DuckPAN 
+RUN cpanm --notest --skip-installed App::DuckPAN 
 
 # Install Dependencies for Spice and Goodies
 RUN git clone --depth=50 https://github.com/duckduckgo/zeroclickinfo-spice.git


### PR DESCRIPTION
- `Dist::Zilla` has no deps from duckpan.org
- `App::DuckPAN` no longer has any required deps on duckpan.org
  - DDG has been moved to CPAN 

/cc @soleo 
